### PR TITLE
Add environment variable escaping and refactor architecture

### DIFF
--- a/bkmr-lsp/Cargo.lock
+++ b/bkmr-lsp/Cargo.lock
@@ -27,6 +27,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "0.6.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ae563653d1938f79b1ab1b5e668c87c76a9930414574a6583a7b7e11a8e6192"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "862ed96ca487e809f1c8e5a8447f6ee2cf102f846893800b20cebdf541fc6bbd"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e231f6134f61b71076a3eab506c379d4f36122f2af15a9ff04415ea4c3339e2"
+dependencies = [
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e0633414522a32ffaac8ac6cc8f748e090c5717661fddeea04219e2344f5f2a"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -105,7 +155,7 @@ dependencies = [
  "miniz_oxide",
  "object",
  "rustc-demangle",
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -127,6 +177,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "atty",
+ "clap",
  "lazy_static",
  "regex",
  "serde",
@@ -150,6 +201,52 @@ name = "cfg-if"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fd1289c04a9ea8cb22300a459a72a385d7c73d3259e2ed7dcb2af674838cfa9"
+
+[[package]]
+name = "clap"
+version = "4.5.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fc0e74a703892159f5ae7d3aac52c8e6c392f5ae5f359c70b5881d60aaac318"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3e7f4214277f3c7aa526a59dd3fbe306a370daee1f8b7b8c987069cd8e888a8"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.5.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14cb31bb0a7d536caef2639baa7fad459e15c3144efefa6dbd1c84562c4739f6"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "dashmap"
@@ -272,6 +369,12 @@ name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
@@ -407,6 +510,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
+
+[[package]]
 name = "itoa"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -491,7 +600,7 @@ checksum = "78bed444cc8a2160f01cbcf811ef18cac863ad68ae8ca62092e8db51d51c761c"
 dependencies = [
  "libc",
  "wasi",
- "windows-sys",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -520,6 +629,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
+name = "once_cell_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
+
+[[package]]
 name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -545,7 +660,7 @@ dependencies = [
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -764,7 +879,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "233504af464074f9d066d7b5416c5f9b894a5862a6506e306f7b816cdd6f1807"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -772,6 +887,12 @@ name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
@@ -852,7 +973,7 @@ dependencies = [
  "slab",
  "socket2",
  "tokio-macros",
- "windows-sys",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1049,6 +1170,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
 name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1083,12 +1210,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows-link"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
+
+[[package]]
 name = "windows-sys"
 version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.3",
 ]
 
 [[package]]
@@ -1097,14 +1239,31 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm 0.52.6",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5fe6031c4041849d7c496a8ded650796e7b6ecc19df1a431c1a363342e5dc91"
+dependencies = [
+ "windows-link",
+ "windows_aarch64_gnullvm 0.53.0",
+ "windows_aarch64_msvc 0.53.0",
+ "windows_i686_gnu 0.53.0",
+ "windows_i686_gnullvm 0.53.0",
+ "windows_i686_msvc 0.53.0",
+ "windows_x86_64_gnu 0.53.0",
+ "windows_x86_64_gnullvm 0.53.0",
+ "windows_x86_64_msvc 0.53.0",
 ]
 
 [[package]]
@@ -1114,10 +1273,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -1126,10 +1297,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1dc67659d35f387f5f6c479dc4e28f1d4bb90ddd1a5d3da2e5d97b42d6272c3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -1138,10 +1321,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -1150,10 +1345,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
 
 [[package]]
 name = "writeable"

--- a/bkmr-lsp/Cargo.toml
+++ b/bkmr-lsp/Cargo.toml
@@ -26,6 +26,7 @@ tracing = "0.1.41"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 atty = "0.2.14"
 regex = "1"
+clap = { version = "4", features = ["derive"] }
 
 [dev-dependencies]
 tokio-test = "0.4.4"

--- a/bkmr-lsp/src/backend.rs
+++ b/bkmr-lsp/src/backend.rs
@@ -6,7 +6,9 @@ use std::path::Path;
 use tower_lsp::{Client, LanguageServer, jsonrpc::Result as LspResult, lsp_types::*};
 use tracing::{debug, error, info, instrument, warn};
 
-use crate::services::LanguageTranslator;
+use crate::domain::CompletionContext;
+use crate::repositories::{BkmrRepository, RepositoryConfig};
+use crate::services::CompletionService;
 
 /// Language-specific information for Rust pattern translation
 #[derive(Debug, Clone)]
@@ -50,6 +52,7 @@ pub struct BkmrSnippet {
 pub struct BkmrLspBackend {
     client: Client,
     config: BkmrConfig,
+    completion_service: CompletionService,
     /// Cache of document contents to extract prefixes
     document_cache: std::sync::Arc<std::sync::RwLock<std::collections::HashMap<String, String>>>,
     /// Cache of document language IDs for filetype-based filtering
@@ -63,9 +66,22 @@ impl BkmrLspBackend {
 
     pub fn with_config(client: Client, config: BkmrConfig) -> Self {
         debug!("Creating BkmrLspBackend with config: {:?}", config);
+        
+        // Create repository with configuration from BkmrConfig
+        let repo_config = RepositoryConfig {
+            binary_path: config.bkmr_binary.clone(),
+            max_results: config.max_completions,
+            timeout_seconds: 10,
+        };
+        let repository = std::sync::Arc::new(BkmrRepository::new(repo_config));
+        
+        // Create completion service with repository and configuration
+        let completion_service = CompletionService::with_config(repository, config.clone());
+        
         Self {
             client,
             config,
+            completion_service,
             document_cache: std::sync::Arc::new(std::sync::RwLock::new(
                 std::collections::HashMap::new(),
             )),
@@ -141,285 +157,11 @@ impl BkmrLspBackend {
         cache.get(&uri.to_string()).cloned()
     }
 
-    /// Build FTS query for snippets that includes both language-specific and universal snippets
-    fn build_snippet_fts_query(&self, language_id: Option<&str>) -> Option<String> {
-        Self::build_snippet_fts_query_static(language_id)
-    }
 
-    /// Static version of FTS query builder
-    fn build_snippet_fts_query_static(language_id: Option<&str>) -> Option<String> {
-        if let Some(lang) = language_id {
-            if !lang.trim().is_empty() {
-                // Query for either (language AND _snip_) OR (universal AND _snip_)
-                return Some(format!(
-                    r#"(tags:{} AND tags:"_snip_") OR (tags:universal AND tags:"_snip_")"#,
-                    lang
-                ));
-            }
-        }
-        // Fallback: just get all snippets with _snip_ tag
-        Some(r#"tags:"_snip_""#.to_string())
-    }
 
-    /// Process content line by line to preserve newlines properly
-    fn translate_rust_patterns_line_by_line(content: &str, target_lang: &LanguageInfo) -> String {
-        let lines: Vec<&str> = content.split('\n').collect();
-        let mut processed_lines = Vec::new();
 
-        // Compile regexes once outside the loop
-        let line_start_comment_re =
-            regex::Regex::new(r"^(\s*)//\s*(.*)$").expect("valid line comment regex");
-        let line_end_comment_re =
-            regex::Regex::new(r"^(.+?)(\s+)//\s*(.*)$").expect("valid end comment regex");
-        let indent_re = regex::Regex::new(r"^( {4})+").expect("valid indent regex");
 
-        for line in lines {
-            let mut processed_line = line.to_string();
 
-            // Process line comments (//)
-            if let Some(target_comment) = &target_lang.line_comment {
-                // Start of line comments
-                if let Some(captures) = line_start_comment_re.captures(line) {
-                    processed_line = format!("{}{} {}", &captures[1], target_comment, &captures[2]);
-                }
-                // End of line comments (after code)
-                else if let Some(captures) = line_end_comment_re.captures(line) {
-                    processed_line = format!(
-                        "{}{}{} {}",
-                        &captures[1], &captures[2], target_comment, &captures[3]
-                    );
-                }
-            } else if let Some((block_start, block_end)) = &target_lang.block_comment {
-                // For languages without line comments, use block comments
-                if let Some(captures) = line_start_comment_re.captures(line) {
-                    processed_line = format!(
-                        "{}{} {} {}",
-                        &captures[1], block_start, &captures[2], block_end
-                    );
-                } else if let Some(captures) = line_end_comment_re.captures(line) {
-                    processed_line = format!(
-                        "{}{}{} {} {}",
-                        &captures[1], &captures[2], block_start, &captures[3], block_end
-                    );
-                }
-            }
-
-            // Process indentation
-            if target_lang.indent_char != "    " {
-                if let Some(captures) = indent_re.captures(&processed_line) {
-                    let rust_indent_count = captures[0].len() / 4;
-                    let new_indent = target_lang.indent_char.repeat(rust_indent_count);
-                    processed_line = processed_line.replacen(&captures[0], &new_indent, 1);
-                }
-            }
-
-            processed_lines.push(processed_line);
-        }
-
-        processed_lines.join("\n")
-    }
-
-    /// Public static version for testing
-    #[cfg(test)]
-    pub fn build_snippet_fts_query_for_test(language_id: Option<&str>) -> Option<String> {
-        Self::build_snippet_fts_query_static(language_id)
-    }
-
-    /// Execute bkmr command and return parsed snippets
-    #[instrument(skip(self))]
-    async fn fetch_snippets(
-        &self,
-        prefix: Option<&str>,
-        language_id: Option<&str>,
-    ) -> Result<Vec<BkmrSnippet>> {
-        let mut args = vec![
-            "search".to_string(),
-            "--json".to_string(),
-            "--interpolate".to_string(), // Always use interpolation
-            "--limit".to_string(),
-            self.config.max_completions.to_string(),
-        ];
-
-        // Build FTS query that combines language-specific and universal snippets
-        let mut fts_parts = Vec::new();
-
-        // Add language + universal snippet query
-        if let Some(snippet_query) = self.build_snippet_fts_query(language_id) {
-            fts_parts.push(format!("({})", snippet_query));
-            debug!("Using snippet query: {}", snippet_query);
-        }
-
-        // Add search term if prefix is provided and not empty
-        if let Some(p) = prefix {
-            if !p.trim().is_empty() {
-                // Use title prefix search for better snippet matching
-                fts_parts.push(format!("metadata:{}*", p));
-                debug!("Using search prefix: {}", p);
-            }
-        }
-
-        // Combine all FTS parts with AND logic
-        if !fts_parts.is_empty() {
-            let fts_query = if fts_parts.len() == 1 {
-                fts_parts.into_iter().next().expect("at least one FTS part")
-            } else {
-                fts_parts.join(" AND ")
-            };
-            args.push(fts_query);
-            debug!(
-                "Final FTS query: {}",
-                args.last().expect("FTS query in args")
-            );
-        }
-
-        debug!("Executing bkmr with args: {:?}", args);
-
-        // Add timeout to prevent hanging
-        let command_future = tokio::process::Command::new(&self.config.bkmr_binary)
-            .args(&args)
-            .output();
-
-        let output =
-            match tokio::time::timeout(std::time::Duration::from_secs(10), command_future).await {
-                Ok(Ok(output)) => output,
-                Ok(Err(e)) => {
-                    error!("Failed to execute bkmr: {}", e);
-                    return Err(anyhow!("Failed to execute bkmr: {}", e));
-                }
-                Err(_) => {
-                    error!("bkmr command timed out after 10 seconds");
-                    return Err(anyhow!("bkmr command timed out"));
-                }
-            };
-
-        if !output.status.success() {
-            let stderr = String::from_utf8_lossy(&output.stderr);
-            error!("bkmr command failed with stderr: {}", stderr);
-            return Err(anyhow!("bkmr command failed: {}", stderr));
-        }
-
-        let stdout_str = String::from_utf8_lossy(&output.stdout);
-
-        if stdout_str.trim().is_empty() {
-            debug!("Empty output from bkmr");
-            return Ok(Vec::new());
-        }
-
-        let snippets: Vec<BkmrSnippet> = serde_json::from_str(&stdout_str).map_err(|e| {
-            error!("Failed to parse bkmr JSON output: {}", e);
-            error!("Raw output was: {}", stdout_str);
-            anyhow!("Failed to parse bkmr JSON output: {}", e)
-        })?;
-
-        info!(
-            "Successfully fetched {} interpolated snippets",
-            snippets.len()
-        );
-        Ok(snippets)
-    }
-
-    /// Translate Rust syntax patterns in universal snippets to target language
-    pub fn translate_rust_patterns(&self, content: &str, language_id: &str, uri: &Url) -> String {
-        let target_lang = self.get_language_info(language_id);
-
-        debug!("Translating Rust patterns for language: {}", language_id);
-        debug!("Input content: {:?}", content);
-        debug!("Content length: {} bytes", content.len());
-
-        // Use line-by-line processing to preserve newlines
-        let mut processed_content =
-            Self::translate_rust_patterns_line_by_line(content, &target_lang);
-
-        // Replace Rust block comments (/* */) with target language block comments
-        if let Some((target_start, target_end)) = &target_lang.block_comment {
-            let block_comment_regex = regex::RegexBuilder::new(r"/\*(.*?)\*/")
-                .dot_matches_new_line(true)
-                .build()
-                .expect("compile block comment regex");
-            processed_content = block_comment_regex
-                .replace_all(&processed_content, |caps: &regex::Captures| {
-                    format!("{}{}{}", target_start, &caps[1], target_end)
-                })
-                .to_string();
-        }
-
-        // Add file name replacement for simple relative path
-        if processed_content.contains("{{ filename }}") {
-            let filename = uri.path().split('/').next_back().unwrap_or("untitled");
-            processed_content = processed_content.replace("{{ filename }}", filename);
-        }
-
-        debug!("Rust pattern translation complete");
-        debug!("Final content: {:?}", processed_content);
-        debug!("Final content length: {} bytes", processed_content.len());
-        processed_content
-    }
-
-    /// Convert bkmr snippet to LSP completion item with proper text replacement
-    fn snippet_to_completion_item_with_trigger(
-        &self,
-        snippet: &BkmrSnippet,
-        query: &str,
-        replacement_range: Option<Range>,
-        language_id: &str,
-        uri: &Url,
-    ) -> CompletionItem {
-        // Check if this is a universal snippet and process accordingly
-        let translated_content = if snippet.tags.contains(&"universal".to_string()) {
-            debug!("Processing universal snippet: {}", snippet.title);
-            debug!("Original content: {:?}", snippet.url);
-            let translated = self.translate_rust_patterns(&snippet.url, language_id, uri);
-            debug!("Translated content: {:?}", translated);
-            translated
-        } else {
-            // Regular snippet - use content as-is
-            snippet.url.clone()
-        };
-
-        // Apply environment variable escaping if enabled
-        let snippet_content = LanguageTranslator::escape_environment_variables(
-            &translated_content,
-            self.config.escape_variables,
-        );
-        let label = snippet.title.clone();
-
-        debug!(
-            "Creating completion item: query='{}', label='{}', content_preview='{}'",
-            query,
-            label,
-            snippet_content.chars().take(20).collect::<String>()
-        );
-
-        let mut completion_item = CompletionItem {
-            label: label.clone(),
-            kind: Some(CompletionItemKind::SNIPPET), // TODO: Snippet, TEXT
-            detail: Some("bkmr snippet".to_string()),
-            documentation: Some(Documentation::String(if snippet_content.len() > 500 {
-                format!("{}...", &snippet_content[..500])
-            } else {
-                snippet_content.clone()
-            })),
-            insert_text_format: Some(InsertTextFormat::SNIPPET), // TODO: Snippet, PLAIN_TEXT
-            filter_text: Some(label.clone()),
-            sort_text: Some(label.clone()),
-            ..Default::default()
-        };
-
-        // Use TextEdit for proper replacement if we have a range
-        if let Some(range) = replacement_range {
-            completion_item.text_edit = Some(CompletionTextEdit::Edit(TextEdit {
-                range,
-                new_text: snippet_content,
-            }));
-            debug!("Set text_edit for range replacement: {:?}", range);
-        } else {
-            // Fallback to insert_text for backward compatibility
-            completion_item.insert_text = Some(snippet_content);
-            debug!("Using fallback insert_text (no range available)");
-        }
-
-        completion_item
-    }
 
     /// Check if bkmr binary is available
     #[instrument(skip(self))]
@@ -566,73 +308,7 @@ impl BkmrLspBackend {
         }
     }
 
-    /// Test-only method to create language info without backend instance
-    #[cfg(test)]
-    pub fn get_language_info_static(language_id: &str) -> LanguageInfo {
-        match language_id.to_lowercase().as_str() {
-            "rust" => LanguageInfo {
-                line_comment: Some("//".to_string()),
-                block_comment: Some(("/*".to_string(), "*/".to_string())),
-                indent_char: "    ".to_string(),
-            },
-            "python" => LanguageInfo {
-                line_comment: Some("#".to_string()),
-                block_comment: Some(("\"\"\"".to_string(), "\"\"\"".to_string())),
-                indent_char: "    ".to_string(),
-            },
-            "javascript" => LanguageInfo {
-                line_comment: Some("//".to_string()),
-                block_comment: Some(("/*".to_string(), "*/".to_string())),
-                indent_char: "  ".to_string(),
-            },
-            "go" => LanguageInfo {
-                line_comment: Some("//".to_string()),
-                block_comment: Some(("/*".to_string(), "*/".to_string())),
-                indent_char: "\t".to_string(),
-            },
-            "html" => LanguageInfo {
-                line_comment: None,
-                block_comment: Some(("<!--".to_string(), "-->".to_string())),
-                indent_char: "  ".to_string(),
-            },
-            _ => LanguageInfo {
-                line_comment: Some("#".to_string()),
-                block_comment: None,
-                indent_char: "    ".to_string(),
-            },
-        }
-    }
 
-    /// Test-only method to translate Rust patterns without backend instance
-    #[cfg(test)]
-    pub fn translate_rust_patterns_static(content: &str, language_id: &str, uri: &Url) -> String {
-        let target_lang = Self::get_language_info_static(language_id);
-
-        // Use line-by-line processing to preserve newlines
-        let mut processed_content =
-            Self::translate_rust_patterns_line_by_line(content, &target_lang);
-
-        // Handle block comments (these can span multiple lines)
-        if let Some((target_start, target_end)) = &target_lang.block_comment {
-            let block_comment_regex = regex::RegexBuilder::new(r"/\*(.*?)\*/")
-                .dot_matches_new_line(true)
-                .build()
-                .expect("compile block comment regex");
-            processed_content = block_comment_regex
-                .replace_all(&processed_content, |caps: &regex::Captures| {
-                    format!("{}{}{}", target_start, &caps[1], target_end)
-                })
-                .to_string();
-        }
-
-        // Replace filename
-        if processed_content.contains("{{ filename }}") {
-            let filename = uri.path().split('/').next_back().unwrap_or("untitled");
-            processed_content = processed_content.replace("{{ filename }}", filename);
-        }
-
-        processed_content
-    }
 
     /// Legacy method for backward compatibility - uses new language info system
     fn get_comment_syntax(&self, file_path: &str) -> &'static str {
@@ -935,44 +611,28 @@ impl LanguageServer for BkmrLspBackend {
         let language_id = self.get_language_id(uri);
         debug!("Document language ID: {:?}", language_id);
 
-        // Extract query and range information
-        let (query_str, replacement_range) = if let Some((query, range)) = query_info {
+        // Create completion context for the service
+        let mut context = CompletionContext::new(
+            uri.clone(),
+            position,
+            language_id
+        );
+        
+        // Add query information if extracted
+        if let Some((query, range)) = query_info {
             debug!("Query: '{}', Range: {:?}", query, range);
-            (query, Some(range))
+            context = context.with_query(crate::domain::CompletionQuery::new(query, range));
         } else {
             debug!("No query extracted, using empty query");
-            (String::new(), None)
-        };
+        }
 
-        match self
-            .fetch_snippets(
-                if query_str.is_empty() {
-                    None
-                } else {
-                    Some(&query_str)
-                },
-                language_id.as_deref(),
-            )
-            .await
-        {
-            Ok(snippets) => {
-                let completion_items: Vec<CompletionItem> = snippets
-                    .iter()
-                    .map(|snippet| {
-                        self.snippet_to_completion_item_with_trigger(
-                            snippet,
-                            &query_str,
-                            replacement_range,
-                            language_id.as_deref().unwrap_or("unknown"),
-                            uri,
-                        )
-                    })
-                    .collect();
-
+        // Use CompletionService to get completion items
+        match self.completion_service.get_completions(&context).await {
+            Ok(completion_items) => {
                 info!(
                     "Returning {} completion items for query: {:?}",
                     completion_items.len(),
-                    query_str
+                    context.get_query_text().unwrap_or("")
                 );
 
                 // Only log first few items to reduce noise in LSP logs
@@ -992,11 +652,11 @@ impl LanguageServer for BkmrLspBackend {
                 })))
             }
             Err(e) => {
-                error!("Failed to fetch snippets: {}", e);
+                error!("Failed to get completions: {}", e);
                 self.client
                     .log_message(
                         MessageType::ERROR,
-                        &format!("Failed to fetch snippets: {}", e),
+                        &format!("Failed to get completions: {}", e),
                     )
                     .await;
                 Ok(Some(CompletionResponse::Array(vec![])))

--- a/bkmr-lsp/tests/test_error_handling.rs
+++ b/bkmr-lsp/tests/test_error_handling.rs
@@ -13,6 +13,7 @@ async fn test_config_edge_cases() {
     let config = BkmrConfig {
         bkmr_binary: "".to_string(),
         max_completions: 0,
+        escape_variables: true,
     };
 
     assert_eq!(config.bkmr_binary, "");


### PR DESCRIPTION
## Summary

- Add environment variable escaping in LSP snippets with configurable CLI option
- Consolidate duplicate snippet processing methods using clean architecture pattern
- Add comprehensive CLI argument parsing with clap integration

## Key Features

### Environment Variable Escaping
- **Default behavior**: Escape shell environment variables ($HOME, $USER, ${VAR}) to prevent misinterpretation as LSP tabstops
- **CLI control**: `--no-escape-vars` flag to disable escaping when needed
- **Smart detection**: Preserves LSP snippet syntax ($1, ${2:default}, ${1|choice1,choice2|}) while escaping environment variables
- **Comprehensive escaping**: Handles both simple ($VAR) and braced (${VAR}) environment variable formats

### Architecture Improvements
- **Eliminate duplication**: Remove duplicate snippet conversion methods between backend and service layer
- **Clean architecture**: Consolidate to single CompletionService pattern with proper separation of concerns

### CLI Enhancements
- **Clap integration**: Professional command-line argument parsing with help generation
- **Version support**: Automatic version display from Cargo.toml
- **Configuration validation**: Proper argument validation and error reporting

## Breaking Changes
None - all existing functionality preserved with opt-out capability for new escaping behavior.