### PR TITLE
Add --no-interpolation CLI option to control bkmr template processing

### DIFF
--- a/bkmr-lsp/src/backend.rs
+++ b/bkmr-lsp/src/backend.rs
@@ -24,6 +24,7 @@ pub struct BkmrConfig {
     pub bkmr_binary: String,
     pub max_completions: usize,
     pub escape_variables: bool,
+    pub enable_interpolation: bool,
 }
 
 impl Default for BkmrConfig {
@@ -32,6 +33,7 @@ impl Default for BkmrConfig {
             bkmr_binary: "bkmr".to_string(),
             max_completions: 50,
             escape_variables: true,
+            enable_interpolation: true,
         }
     }
 }
@@ -72,6 +74,7 @@ impl BkmrLspBackend {
             binary_path: config.bkmr_binary.clone(),
             max_results: config.max_completions,
             timeout_seconds: 10,
+            enable_interpolation: config.enable_interpolation,
         };
         let repository = std::sync::Arc::new(BkmrRepository::new(repo_config));
         

--- a/bkmr-lsp/src/main.rs
+++ b/bkmr-lsp/src/main.rs
@@ -12,6 +12,10 @@ struct Args {
     /// Disable environment variable escaping in LSP snippets
     #[arg(long, help = "Disable escaping of environment variables ($VAR) in snippet content")]
     no_escape_vars: bool,
+
+    /// Disable bkmr template interpolation
+    #[arg(long, help = "Disable bkmr template interpolation (serve raw templates instead of processed content)")]
+    no_interpolation: bool,
 }
 
 #[tokio::main]
@@ -55,6 +59,7 @@ async fn main() {
     // Create configuration from CLI args
     let config = BkmrConfig {
         escape_variables: !args.no_escape_vars,
+        enable_interpolation: !args.no_interpolation,
         ..Default::default()
     };
 

--- a/bkmr-lsp/src/repositories/bkmr_repository.rs
+++ b/bkmr-lsp/src/repositories/bkmr_repository.rs
@@ -20,10 +20,14 @@ impl BkmrRepository {
         let mut args = vec![
             "search".to_string(),
             "--json".to_string(),
-            "--interpolate".to_string(), // Always use interpolation
             "--limit".to_string(),
             filter.max_results.to_string(),
         ];
+
+        // Conditionally add interpolation flag
+        if self.config.enable_interpolation {
+            args.push("--interpolate".to_string());
+        }
 
         // Build FTS query that combines language-specific and universal snippets
         let mut fts_parts = Vec::new();

--- a/bkmr-lsp/src/repositories/snippet_repository.rs
+++ b/bkmr-lsp/src/repositories/snippet_repository.rs
@@ -19,6 +19,7 @@ pub struct RepositoryConfig {
     pub binary_path: String,
     pub max_results: usize,
     pub timeout_seconds: u64,
+    pub enable_interpolation: bool,
 }
 
 impl Default for RepositoryConfig {
@@ -27,6 +28,7 @@ impl Default for RepositoryConfig {
             binary_path: "bkmr".to_string(),
             max_results: 50,
             timeout_seconds: 10,
+            enable_interpolation: true,
         }
     }
 }

--- a/bkmr-lsp/tests/test_error_handling.rs
+++ b/bkmr-lsp/tests/test_error_handling.rs
@@ -14,6 +14,7 @@ async fn test_config_edge_cases() {
         bkmr_binary: "".to_string(),
         max_completions: 0,
         escape_variables: true,
+        enable_interpolation: false,
     };
 
     assert_eq!(config.bkmr_binary, "");


### PR DESCRIPTION
## Summary

Add new CLI option `--no-interpolation` to disable server-side bkmr template interpolation, giving users control over whether templates are processed before serving to LSP clients.

## Changes

### Core Implementation
- Add `--no-interpolation` CLI flag using clap declarative argument parsing

## Use Cases

The `--no-interpolation` option is useful when:
- Debugging template syntax or variables
- Preferring to handle template processing manually after snippet insertion

With interpolation disabled, raw template syntax is preserved in completions.